### PR TITLE
Optimize Time Spent Tracker: asset loading, sanitization and runtime improvements

### DIFF
--- a/js/time-spent-tracker.js
+++ b/js/time-spent-tracker.js
@@ -1,9 +1,14 @@
 document.addEventListener('DOMContentLoaded', function() {
-    let startTime = Date.now();
+    const startTime = Date.now();
     let totalTimeSpent = 0;
 
     const translations = TimeSpentTracker.translations;
     const settings = TimeSpentTracker.settings;
+    const timeSpentElement = document.getElementById('timeSpent');
+
+    if (!timeSpentElement) {
+        return;
+    }
 
     if (localStorage.getItem('totalTimeSpent')) {
         totalTimeSpent = parseInt(localStorage.getItem('totalTimeSpent'), 10);
@@ -27,18 +32,14 @@ document.addEventListener('DOMContentLoaded', function() {
         const currentTime = Math.floor((Date.now() - startTime) / 1000);
         const totalTime = totalTimeSpent + currentTime;
 
-        window.addEventListener('beforeunload', function() {
-            localStorage.setItem('totalTimeSpent', totalTime);
-        });
-
-        const timeSpentElement = document.getElementById('timeSpent');
-        if (timeSpentElement) {
-            timeSpentElement.textContent = translations.initialMessage + formatTime(totalTime);
-            timeSpentElement.style.color = settings.textColor;
-            timeSpentElement.style.backgroundColor = settings.backgroundColor;
-            timeSpentElement.style.border = `2px solid ${settings.borderColor}`;
-        }
+        timeSpentElement.textContent = translations.initialMessage + formatTime(totalTime);
+        localStorage.setItem('totalTimeSpent', String(totalTime));
     }
 
+    timeSpentElement.style.color = settings.textColor;
+    timeSpentElement.style.backgroundColor = settings.backgroundColor;
+    timeSpentElement.style.border = `2px solid ${settings.borderColor}`;
+
+    updateTimeSpent();
     setInterval(updateTimeSpent, 1000);
 });

--- a/timespend.php
+++ b/timespend.php
@@ -17,32 +17,132 @@ function time_spent_tracker_load_textdomain() {
 }
 add_action('plugins_loaded', 'time_spent_tracker_load_textdomain');
 
+/**
+ * Return default plugin settings.
+ *
+ * @return array<string, string>
+ */
+function time_spent_tracker_get_default_settings() {
+    return [
+        'text_color' => '#4758D0',
+        'background_color' => 'white',
+        'border_color' => '#4758D0',
+        'language' => 'en',
+    ];
+}
+
+/**
+ * Validate a color value.
+ *
+ * @param string $color Raw color value.
+ * @return string
+ */
+function time_spent_tracker_sanitize_color($color) {
+    $color = trim((string) $color);
+    $hex_color = sanitize_hex_color($color);
+
+    if (!empty($hex_color)) {
+        return $hex_color;
+    }
+
+    if (preg_match('/^[a-zA-Z]+$/', $color)) {
+        return sanitize_text_field($color);
+    }
+
+    return time_spent_tracker_get_default_settings()['background_color'];
+}
+
+/**
+ * Sanitize selected language.
+ *
+ * @param string $language Raw language code.
+ * @return string
+ */
+function time_spent_tracker_sanitize_language($language) {
+    $allowed_languages = ['en', 'ru'];
+    $language = sanitize_text_field((string) $language);
+
+    return in_array($language, $allowed_languages, true) ? $language : time_spent_tracker_get_default_settings()['language'];
+}
+
+/**
+ * Determine whether plugin assets are needed on the current request.
+ *
+ * @return bool
+ */
+function time_spent_tracker_should_enqueue_assets() {
+    if (is_admin()) {
+        return false;
+    }
+
+    if (!is_singular()) {
+        return false;
+    }
+
+    $post = get_post();
+    if (!$post instanceof WP_Post) {
+        return false;
+    }
+
+    return has_shortcode($post->post_content, 'time_spent');
+}
+
+/**
+ * Return translated labels based on selected plugin language.
+ *
+ * @return array<string, string>
+ */
+function time_spent_tracker_get_translations() {
+    $selected_language = get_option('time_spent_language', time_spent_tracker_get_default_settings()['language']);
+
+    $labels = [
+        'initialMessage' => [
+            'en' => __('You have spent on the site: ', 'time-spent-tracker'),
+            'ru' => __('Вы провели на сайте: ', 'time-spent-tracker'),
+        ],
+        'days' => [
+            'en' => __(' days ', 'time-spent-tracker'),
+            'ru' => __(' дн ', 'time-spent-tracker'),
+        ],
+        'hours' => [
+            'en' => __(' hours ', 'time-spent-tracker'),
+            'ru' => __(' ч ', 'time-spent-tracker'),
+        ],
+        'minutes' => [
+            'en' => __(' minutes ', 'time-spent-tracker'),
+            'ru' => __(' мин ', 'time-spent-tracker'),
+        ],
+        'seconds' => [
+            'en' => __(' seconds ', 'time-spent-tracker'),
+            'ru' => __(' сек', 'time-spent-tracker'),
+        ],
+    ];
+
+    $result = [];
+    foreach ($labels as $key => $values) {
+        $result[$key] = $values[$selected_language] ?? $values['en'];
+    }
+
+    return $result;
+}
+
 // Enqueue scripts and styles
 function time_spent_tracker_enqueue_assets() {
-    wp_enqueue_script('time-spent-tracker-js', plugins_url('js/time-spent-tracker.js', __FILE__), [], '1.0', true);
-    wp_enqueue_style('time-spent-tracker-css', plugins_url('css/time-spent-tracker.css', __FILE__), [], '1.0');
+    if (!time_spent_tracker_should_enqueue_assets()) {
+        return;
+    }
+
+    $defaults = time_spent_tracker_get_default_settings();
+
+    wp_enqueue_script('time-spent-tracker-js', plugins_url('js/time-spent-tracker.js', __FILE__), [], '1.1', true);
+    wp_enqueue_style('time-spent-tracker-css', plugins_url('css/time-spent-tracker.css', __FILE__), [], '1.1');
 
     wp_localize_script('time-spent-tracker-js', 'TimeSpentTracker', [
-        'translations' => [
-            'en' => [
-                'initialMessage' => __('You have spent on the site: ', 'time-spent-tracker'),
-                'days' => __(' days ', 'time-spent-tracker'),
-                'hours' => __(' hours ', 'time-spent-tracker'),
-                'minutes' => __(' minutes ', 'time-spent-tracker'),
-                'seconds' => __(' seconds ', 'time-spent-tracker'),
-            ],
-            'ru' => [
-                'initialMessage' => __('Вы провели на сайте: ', 'time-spent-tracker'),
-                'days' => __(' дн ', 'time-spent-tracker'),
-                'hours' => __(' ч ', 'time-spent-tracker'),
-                'minutes' => __(' мин ', 'time-spent-tracker'),
-                'seconds' => __(' сек', 'time-spent-tracker'),
-            ],
-        ],
+        'translations' => time_spent_tracker_get_translations(),
         'settings' => [
-            'textColor' => esc_attr(get_option('time_spent_text_color', '#4758D0')),
-            'backgroundColor' => esc_attr(get_option('time_spent_background_color', 'white')),
-            'borderColor' => esc_attr(get_option('time_spent_border_color', '#4758D0')),
+            'textColor' => esc_attr(get_option('time_spent_text_color', $defaults['text_color'])),
+            'backgroundColor' => esc_attr(get_option('time_spent_background_color', $defaults['background_color'])),
+            'borderColor' => esc_attr(get_option('time_spent_border_color', $defaults['border_color'])),
         ],
     ]);
 }
@@ -56,15 +156,16 @@ add_shortcode('time_spent', 'time_spent_tracker_display_time');
 
 // Register settings
 function time_spent_tracker_register_settings() {
-    add_option('time_spent_text_color', '#4758D0');
-    add_option('time_spent_background_color', 'white');
-    add_option('time_spent_border_color', '#4758D0');
-    add_option('time_spent_language', 'en');
+    $defaults = time_spent_tracker_get_default_settings();
+    add_option('time_spent_text_color', $defaults['text_color']);
+    add_option('time_spent_background_color', $defaults['background_color']);
+    add_option('time_spent_border_color', $defaults['border_color']);
+    add_option('time_spent_language', $defaults['language']);
 
-    register_setting('time_spent_tracker_options_group', 'time_spent_text_color');
-    register_setting('time_spent_tracker_options_group', 'time_spent_background_color');
-    register_setting('time_spent_tracker_options_group', 'time_spent_border_color');
-    register_setting('time_spent_tracker_options_group', 'time_spent_language');
+    register_setting('time_spent_tracker_options_group', 'time_spent_text_color', ['sanitize_callback' => 'time_spent_tracker_sanitize_color']);
+    register_setting('time_spent_tracker_options_group', 'time_spent_background_color', ['sanitize_callback' => 'time_spent_tracker_sanitize_color']);
+    register_setting('time_spent_tracker_options_group', 'time_spent_border_color', ['sanitize_callback' => 'time_spent_tracker_sanitize_color']);
+    register_setting('time_spent_tracker_options_group', 'time_spent_language', ['sanitize_callback' => 'time_spent_tracker_sanitize_language']);
 }
 add_action('admin_init', 'time_spent_tracker_register_settings');
 


### PR DESCRIPTION
### Motivation
- Reduce frontend overhead by loading assets only where the `[time_spent]` shortcode is present and avoid unnecessary per-tick work in JS. 
- Harden settings storage to prevent invalid color/language values being saved. 
- Reduce localization payload sent to the front-end by sending only the selected language strings.

### Description
- Added `time_spent_tracker_get_default_settings`, `time_spent_tracker_sanitize_color` and `time_spent_tracker_sanitize_language` to centralize defaults and sanitize option values. 
- Introduced `time_spent_tracker_should_enqueue_assets` and updated `time_spent_tracker_enqueue_assets` to enqueue JS/CSS only on singular pages that contain the `time_spent` shortcode and to localize only the selected language via `time_spent_tracker_get_translations`. 
- Registered options with `register_setting(..., ['sanitize_callback' => ...])` and used defaults in `add_option` to ensure safe saved values. 
- Optimized `js/time-spent-tracker.js` by using a single DOM lookup for `#timeSpent`, removing the repeated `beforeunload` registration inside the interval, persisting `totalTime` from the interval callback, applying inline styles once at init, and performing an initial render immediately.

### Testing
- Ran `php -l timespend.php` and it reported no syntax errors. 
- Ran `node --check js/time-spent-tracker.js` and it reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac7b5db29883259c0bca884eb29ea8)